### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - sui-bin:/root/sui_bin
 
   walrus-deploy:
-    restart: no
+    restart: "no"
     depends_on:
       sui-localnet:
         condition: service_healthy


### PR DESCRIPTION
Change value type to string to get past this error:

ERROR: The Compose file './docker-compose.yaml' is invalid because: services.walrus-deploy.restart contains an invalid type, it should be a string