### PR TITLE
Quoted variables to prevent word splitting and globbing issues

### DIFF
--- a/files/deploy-walrus.sh
+++ b/files/deploy-walrus.sh
@@ -1,9 +1,7 @@
-# Copyright (c) Mysten Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
 #!/bin/bash
 
-# use EPOCH_DURATION to set the epoch duration, default is 1h
-EPOCH_DURATION=${EPOCH_DURATION:-1h}
+# Use EPOCH_DURATION to set the epoch duration, default is 1h
+EPOCH_DURATION="${EPOCH_DURATION:-1h}"
 
 rm -rf walrus-docs
 git clone https://github.com/MystenLabs/walrus-docs.git
@@ -20,7 +18,7 @@ rm -rf /opt/walrus/outputs/*
   --host-addresses 10.0.0.10 10.0.0.11 10.0.0.12 10.0.0.13 \
   --storage-price 5 \
   --write-price 1 \
-  --epoch-duration $EPOCH_DURATION >/opt/walrus/outputs/deploy
+  --epoch-duration "$EPOCH_DURATION" >/opt/walrus/outputs/deploy
 
 /opt/walrus/bin/walrus-deploy generate-dry-run-configs \
   --working-dir /opt/walrus/outputs


### PR DESCRIPTION
few minor corrections and improvements -

I've quoted the EPOCH_DURATION variable and  Comments should start with a capital letter for consistency